### PR TITLE
Introduce password hashing

### DIFF
--- a/MessengerServer/MessengerServer/MainForm.cs
+++ b/MessengerServer/MessengerServer/MainForm.cs
@@ -939,10 +939,16 @@ namespace MessengerServer
                     return false;
                 }
 
-                userName = _accountTable.FindById(id).Login;
+                var row = _accountTable.FindById(id);
+                userName = row.Login;
 
-                if (string.Compare(GetPasswordById(id), password, StringComparison.Ordinal) == 0)
+                if (PasswordHelper.VerifyPassword(password, row.Password, out var migrated))
                 {
+                    if (migrated != row.Password)
+                    {
+                        row.Password = migrated;
+                        _accountAdapter.Update(_accountTable);
+                    }
                     AttachUser(userName, sender);
                     return true;
                 }
@@ -1889,10 +1895,18 @@ namespace MessengerServer
 
                 var user = (UserConnection) _attachedUsers[login];
                 // проверка на хак
-                if (String.Compare(user.Password, password, StringComparison.Ordinal) != 0)
+                if (!PasswordHelper.VerifyPassword(password, user.Password, out var migrated))
                 {
                     sender.SendMessage(MessageHelper.Messages.RegistrationFailedDefault);
                     return;
+                }
+
+                if (migrated != user.Password)
+                {
+                    var rowUpd = _accountTable.FindById(user.Id);
+                    rowUpd.Password = migrated;
+                    _accountAdapter.Update(_accountTable);
+                    user.Password = migrated;
                 }
 
                 var row = _accountTable.FindById(user.Id);
@@ -1997,10 +2011,18 @@ namespace MessengerServer
 
                     var user = (UserConnection) _attachedUsers[login];
                     // проверка на хак
-                    if (string.Compare(user.Password, password, StringComparison.Ordinal) != 0)
+                    if (!PasswordHelper.VerifyPassword(password, user.Password, out var migrated))
                     {
                         sender.SendMessage(MessageHelper.Messages.RegistrationFailedDefault);
                         return;
+                    }
+
+                    if (migrated != user.Password)
+                    {
+                        var rowUpd = _accountTable.FindById(user.Id);
+                        rowUpd.Password = migrated;
+                        _accountAdapter.Update(_accountTable);
+                        user.Password = migrated;
                     }
 
                     senderUser.Add(user);
@@ -2110,8 +2132,10 @@ namespace MessengerServer
                 var br = bt.NewBanReasonsRow();
                 br.Reason = "";
 
+                var hashed = PasswordHelper.HashPassword(data[1]);
+
                 var row = _accountTable.AddAccountRow(data[0],
-                    data[1],
+                    hashed,
                     data[2],
                     data[3],
                     data[4],
@@ -2147,7 +2171,7 @@ namespace MessengerServer
                 var row = _accountTable.FindById(user.Id);
 
                 row.Login = sender.DataArray[0];
-                row.Password = sender.DataArray[1];
+                row.Password = PasswordHelper.HashPassword(sender.DataArray[1]);
                 row.Firstname = sender.DataArray[2];
                 row.Lastname = sender.DataArray[3];
                 row.Email = sender.DataArray[4];

--- a/ServerInterfaceLib/PasswordHelper.cs
+++ b/ServerInterfaceLib/PasswordHelper.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ServerInterfaceLib
+{
+    public static class PasswordHelper
+    {
+        public static string HashPassword(string password)
+        {
+            // generate 16-byte salt
+            var saltBytes = new byte[16];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(saltBytes);
+            }
+            var salt = Convert.ToBase64String(saltBytes);
+
+            using (var sha = SHA256.Create())
+            {
+                var combined = Encoding.UTF8.GetBytes(salt + password);
+                var hash = sha.ComputeHash(combined);
+                return salt + "$" + Convert.ToBase64String(hash);
+            }
+        }
+
+        public static bool VerifyPassword(string inputPassword, string stored, out string migrated)
+        {
+            migrated = stored;
+            if (string.IsNullOrEmpty(stored)) return false;
+            var parts = stored.Split('$');
+            if (parts.Length == 2)
+            {
+                // hashed format
+                var salt = parts[0];
+                var hash = parts[1];
+                using (var sha = SHA256.Create())
+                {
+                    var combined = Encoding.UTF8.GetBytes(salt + inputPassword);
+                    var newHash = Convert.ToBase64String(sha.ComputeHash(combined));
+                    return string.Equals(hash, newHash, StringComparison.Ordinal);
+                }
+            }
+            // fallback plaintext
+            if (stored == inputPassword)
+            {
+                migrated = HashPassword(inputPassword);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/ServerInterfaceLib/ServerInterfaceLib.csproj
+++ b/ServerInterfaceLib/ServerInterfaceLib.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MessageHelper.cs" />
+    <Compile Include="PasswordHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
## Summary
- add new `PasswordHelper` with salted SHA-256 hashing
- update account creation and editing to store hashed passwords
- verify incoming passwords using new helper and migrate plaintext entries

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe34c98dc832c811a38c6672a1126