### PR TITLE
Improve server/client stability

### DIFF
--- a/Messenger Client/Messenger Client/MainForm.cs
+++ b/Messenger Client/Messenger Client/MainForm.cs
@@ -1611,6 +1611,7 @@ namespace Messenger_Client
             {
                 ConnectInterfaceEnable(false);
                 ConnectTimer.Start();
+                _progressCancel = false;
                 _progressThread = new Thread(DoConnectProgress);
                 _progressThread.Start();
                 return true;
@@ -1623,6 +1624,7 @@ namespace Messenger_Client
         }
 
         private Thread _progressThread;
+        private volatile bool _progressCancel;
 
         private readonly string[] _progressText =
         {
@@ -1632,29 +1634,33 @@ namespace Messenger_Client
 
         private void DoConnectProgress()
         {
-            while (true)
+            while (!_progressCancel)
+            {
                 foreach (var t in _progressText)
+                {
+                    if (_progressCancel) break;
                     try
                     {
                         StatusInfo.Text = @"Соединение " + t;
-
                         Thread.Sleep(150);
                     }
                     catch (Exception e)
                     {
-                        ErrorsProc.WriteErrorToLog(e,"");
+                        ErrorsProc.WriteErrorToLog(e, "");
                     }
+                }
+            }
             // ReSharper disable once FunctionNeverReturns
         }
 
         private void ProgressThreadTerminate(string statusInfo)
         {
-            if (_progressThread != null)
-                if (_progressThread.IsAlive)
-                {
-                    _progressThread.Abort();
-                    _progressThread = null;
-                }
+            _progressCancel = true;
+            if (_progressThread != null && _progressThread.IsAlive)
+            {
+                _progressThread.Join(200);
+                _progressThread = null;
+            }
 
             StatusInfo.Text = statusInfo;
         }

--- a/Messenger Client/Messenger Client/RegistrationForm.cs
+++ b/Messenger Client/Messenger Client/RegistrationForm.cs
@@ -217,12 +217,12 @@ namespace Messenger_Client
 
         private void ProgressThreadTerminate()
         {
-            if (_progressThread != null)
-                if (_progressThread.IsAlive)
-                {
-                    _progressThread.Abort();
-                    _progressThread = null;
-                }
+            _progressCancel = true;
+            if (_progressThread != null && _progressThread.IsAlive)
+            {
+                _progressThread.Join(200);
+                _progressThread = null;
+            }
         }
 
         private void connect_Receive(ClientConnection sender, string message)
@@ -463,6 +463,7 @@ namespace Messenger_Client
         {
             try
             {
+                _progressCancel = false;
                 _progressThread = new Thread(DoProgress);
                 _progressThread.Start();
 
@@ -653,18 +654,19 @@ namespace Messenger_Client
 
         private void DoProgress()
         {
-            while (true)
+            while (!_progressCancel)
             {
                 foreach (var item in _progressText)
                 {
+                    if (_progressCancel) break;
                     Progress.Text = item;
                     Thread.Sleep(150);
                 }
             }
-            // ReSharper disable once FunctionNeverReturns
         }
 
         private Thread _progressThread;
+        private volatile bool _progressCancel;
 
         #endregion
     }

--- a/MessengerServer/MessengerServer/MainForm.cs
+++ b/MessengerServer/MessengerServer/MainForm.cs
@@ -615,11 +615,7 @@ namespace MessengerServer
 
                 _cancelClose = false;
 
-                if (_listener != null)
-                {
-                    _listener.Stop();
-                    _listenerThread?.Abort();
-                }
+                StopListener();
 
                 _clients.Clear();
 
@@ -845,12 +841,22 @@ namespace MessengerServer
         private TcpListener _listener;
         private const int Port = 1100;
 
+        private bool _stopListener;
+
         private void StartListener()
         {
+            _stopListener = false;
             _listenerThread = new Thread(DoListen);
             _listenerThread.Start();
 
             ChatAddComment("listener is started");
+        }
+
+        private void StopListener()
+        {
+            _stopListener = true;
+            _listener?.Stop();
+            _listenerThread?.Join(1000);
         }
 
         // ReSharper disable once CollectionNeverQueried.Local
@@ -862,11 +868,12 @@ namespace MessengerServer
             {
                 _listener = new TcpListener(IPAddress.Any, Port);
                 _listener.Start();
-                do
+                while (!_stopListener)
                 {
                     try
                     {
-                        var client = new UserConnection(_listener.AcceptTcpClient());
+                        var tcpClient = _listener.AcceptTcpClient();
+                        var client = new UserConnection(tcpClient);
 
                         client.Receive += OnClientReceive;
                         client.DisconnectEvent += OnDisconnectUser;
@@ -875,16 +882,21 @@ namespace MessengerServer
                         _clients.Add(client);
                         ChatAddComment("Принято новое соединение");
                     }
+                    catch (SocketException)
+                    {
+                        if (_stopListener) break;
+                        throw;
+                    }
                     catch (ServerException e)
                     {
                         ReportAnError(e, "DoListen");
                         ReportAnError();
                     }
-                } while (true);
+                }
             }
             catch (Exception e)
             {
-                if (!_cancelClose && e.Message.IndexOf("Thread was being aborted", StringComparison.Ordinal) != -1) return;
+                if (_stopListener) return;
 
                 ReportAnError(e, "DoListen");
 
@@ -1236,19 +1248,23 @@ namespace MessengerServer
             {
                 ChatAddComment(sender, message);
                 var messSplit = message.Split('|');
+                if (messSplit.Length == 0) return;
+
                 switch (ClientConnectionLib.ClientConnection.GetMessage(messSplit[0]))
                 {
                     case CCMessages.CreateRoom:
-                        CreateRoom(sender, messSplit[1]);
+                        if (messSplit.Length > 1)
+                            CreateRoom(sender, messSplit[1]);
                         break;
                     case CCMessages.Connect:
-                        AuthorizeUser(messSplit[1], messSplit[2], sender);
+                        if (messSplit.Length > 2)
+                            AuthorizeUser(messSplit[1], messSplit[2], sender);
                         break;
                     //*************************************
                     //          Main chat
                     //*************************************
                     case CCMessages.Chat:
-                        if (sender.IsMChatActive)
+                        if (sender.IsMChatActive && messSplit.Length > 1)
                         {
                             UserSay(sender, messSplit[1]);
 
@@ -1271,32 +1287,41 @@ namespace MessengerServer
                         SendAllUsersList(sender);
                         break;
                     case CCMessages.FindUser:
-                        FindUsers(sender, messSplit);
+                        if (messSplit.Length > 1)
+                            FindUsers(sender, messSplit);
                         break;
                     case CCMessages.Disconnect:
                         sender.CloseConnection();
                         break;
                     case CCMessages.Registration:
-                        ChatAddWarning("User want to create new account");
-                        RegisterUser(messSplit, sender);
+                        if (messSplit.Length > 1)
+                        {
+                            ChatAddWarning("User want to create new account");
+                            RegisterUser(messSplit, sender);
+                        }
                         break;
                     case CCMessages.YouAlive:
                         sender.SendMessage(MessageHelper.Messages.ServerAlive);
                         break;
                     case CCMessages.GetProfile: //  login           password
-                        SendProfile(sender, messSplit[1], messSplit[2]);
+                        if (messSplit.Length > 2)
+                            SendProfile(sender, messSplit[1], messSplit[2]);
                         break;
                     case CCMessages.Private:
-                        PrivateProcessing(sender, messSplit);
+                        if (messSplit.Length > 1)
+                            PrivateProcessing(sender, messSplit);
                         break;
                     case CCMessages.AddContact:
-                        AddContact(sender, messSplit);
+                        if (messSplit.Length > 1)
+                            AddContact(sender, messSplit);
                         break;
                     case CCMessages.ToWhite:
-                        UsersToWhite(sender, messSplit);
+                        if (messSplit.Length > 1)
+                            UsersToWhite(sender, messSplit);
                         break;
-                    case CCMessages.ToBlack: 
-                        UsersToBlack(sender, messSplit);
+                    case CCMessages.ToBlack:
+                        if (messSplit.Length > 1)
+                            UsersToBlack(sender, messSplit);
                         break;
                     case CCMessages.GetBw:
                         SendBlackWhite(sender, _params.BwDelay);
@@ -1305,10 +1330,12 @@ namespace MessengerServer
                         Send_BW_State(sender, _params.BwDelay);
                         break;
                     case CCMessages.State:
-                        StateChange(sender, messSplit[1]);
+                        if (messSplit.Length > 1)
+                            StateChange(sender, messSplit[1]);
                         break;
                     case CCMessages.GetEmail:
-                        SendEmail(sender, messSplit[1]);
+                        if (messSplit.Length > 1)
+                            SendEmail(sender, messSplit[1]);
                         break;
                     default:
                         ChatAddString("Unknown message:" + message);

--- a/MessengerServer/MessengerServer/Parametres.cs
+++ b/MessengerServer/MessengerServer/Parametres.cs
@@ -69,28 +69,17 @@ namespace MessengerServer
         {
             try
             {
-                FileStream fs = null;
-                while (fs == null)
+                if (!File.Exists(_path))
                 {
-                    try
-                    {
-                        fs = new FileStream(_path, FileMode.Open, FileAccess.Read);
-                    }
-                    catch (FileNotFoundException e)
-                    {
-                        ErrorsProc.WriteErrorAndMessage(e, "Load in Parametres.cs", false);
-
-                        Parametres prm = new Parametres(ParamsDefault);
-
-                        prm.Save();
-
-                    }
+                    ErrorsProc.WriteErrorAndMessage(new FileNotFoundException(_path), "Load in Parametres.cs", false);
+                    var prm = new Parametres(ParamsDefault);
+                    prm.Save();
                 }
-                BinaryFormatter bf = new BinaryFormatter();
+
+                using var fs = new FileStream(_path, FileMode.Open, FileAccess.Read);
+                var bf = new BinaryFormatter();
 
                 ParamsStruct result = (ParamsStruct)bf.Deserialize(fs);
-
-                fs.Close();
 
                 return result;
             }


### PR DESCRIPTION
## Summary
- add graceful listener shutdown without `Thread.Abort`
- guard message parsing from malformed input
- stop endless config load loop
- cancel progress threads without abrupt aborts

## Testing
- `msbuild Messenger.sln -t:Restore` *(fails: command not found)*
- `dotnet build Messenger.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe6dff5d0832c9caccabf0037bafc